### PR TITLE
feat(gcppubsub): lib to help with parsing gcp pubsub events

### DIFF
--- a/lib/gcppubsub/gcppubsub.go
+++ b/lib/gcppubsub/gcppubsub.go
@@ -1,0 +1,55 @@
+package gcppubsub
+
+import (
+	"context"
+	"embed"
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/cuvva/cuvva-public-go/lib/crpc"
+	"github.com/cuvva/cuvva-public-go/lib/jsonschema"
+	"github.com/wearemojo/mojo-public-go/lib/merr"
+	"github.com/xeipuuv/gojsonschema"
+	"google.golang.org/api/pubsub/v1"
+)
+
+//go:embed *.json
+var schemaFS embed.FS
+
+var (
+	schema             = jsonschema.NewFS(schemaFS).LoadJSONExt
+	ReceiveEventSchema = schema("receive_event")
+)
+
+type IncomingMessage struct {
+	Subscription string                `json:"subscription"`
+	Message      *pubsub.PubsubMessage `json:"message"`
+}
+
+func (im IncomingMessage) GetPayload(ctx context.Context, schema *gojsonschema.Schema, req any) error {
+	bytes, err := base64.StdEncoding.DecodeString(im.Message.Data)
+	if err != nil {
+		return err
+	}
+
+	ld := gojsonschema.NewBytesLoader(bytes)
+
+	result, err := schema.Validate(ld)
+	if err != nil {
+		return merr.Wrap(err, "cannot_validate_message", nil)
+	}
+
+	if err = crpc.CoerceJSONSchemaError(result); err != nil {
+		return err
+	}
+
+	return json.Unmarshal(bytes, req)
+}
+
+func MakeSchema(schema gojsonschema.JSONLoader, pointer *gojsonschema.Schema) (*gojsonschema.Schema, error) {
+	if pointer != nil {
+		return pointer, nil
+	}
+
+	return gojsonschema.NewSchemaLoader().Compile(schema)
+}

--- a/lib/gcppubsub/receive_event.json
+++ b/lib/gcppubsub/receive_event.json
@@ -1,0 +1,53 @@
+{
+	"type": "object",
+	"additionalProperties": false,
+
+	"required": [
+		"subscription",
+		"message"
+	],
+
+	"properties": {
+		"subscription": {
+			"type": "string",
+			"minLength": 1
+		},
+
+		"message": {
+			"type": "object",
+			"additionalProperties": false,
+
+			"required": [
+				"attributes",
+				"data",
+				"message_id",
+				"publish_time"
+			],
+
+			"properties": {
+				"attributes": {
+					"type": "object",
+					"additionalProperties": true
+				},
+
+				"data": {
+					"type": "string",
+					"minLength": 1
+				},
+
+				"message_id": {
+					"type": "string",
+					"minLength": 1
+				},
+
+				"publish_time": {
+					"type": "string",
+					"format": "date-time"
+				},
+
+				"messageId": {},
+				"publishTime": {}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Example usage inside a service

```go
var (
	compiledSchema *gojsonschema.Schema
	event          = jsonschema.NewFS(schemaFS).LoadJSONExt("event-subscription-created")
)

type MyType struct {
	UserID ksuid.ID `json:"user_id"`
}

func (s *Service) ReceiveEvent(ctx context.Context, req *gcppubsub.IncomingMessage) (err error) {
	if compiledSchema, err = gcppubsub.MakeSchema(event, compiledSchema); err != nil {
		return err
	}

	var t MyType
	if err := req.GetPayload(ctx, compiledSchema, &t); err != nil {
		return err
	}

	// do something with the incoming event

	return nil
}
```

```go
rpc.Register("receive_event", "2022-05-06", gcppubsub.ReceiveEventSchema, NoAuth, s.ReceiveEvent)
```