### PR TITLE
feat(jwt): delimit env/service in issuer claim by `;`

### DIFF
--- a/lib/jwt/kmsjwt/signer.go
+++ b/lib/jwt/kmsjwt/signer.go
@@ -93,7 +93,7 @@ func (s *Signer) Sign(ctx context.Context, expiresAt *time.Time, customClaims jw
 	}
 
 	claims := jwtinterface.Claims{
-		"iss": fmt.Sprintf("%s-%s", s.env, s.serviceName),
+		"iss": fmt.Sprintf("%s;%s", s.env, s.serviceName),
 		"iat": time.Now().Unix(),
 		"exp": expiresAt.Unix(),
 	}

--- a/lib/jwt/kmsjwt/verifier.go
+++ b/lib/jwt/kmsjwt/verifier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"strings"
 	"time"
 
 	kmsapi "cloud.google.com/go/kms/apiv1"
@@ -47,12 +48,17 @@ func (s *Verifier) getPublicKey(ctx context.Context, issuer, keyID string) (*ecd
 }
 
 func (s *Verifier) findPublicKey(ctx context.Context, issuer, keyID string) (*ecdsa.PublicKey, error) {
+	env, service, ok := strings.Cut(issuer, ";")
+	if !ok {
+		return nil, merr.New("invalid_issuer", merr.M{"issuer": issuer})
+	}
+
 	path := fmt.Sprintf(
 		"projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s/cryptoKeyVersions/%s",
 		s.projectID,
 		"global",
 		"services",
-		issuer,
+		fmt.Sprintf("%s-%s", env, service),
 		keyID,
 	)
 


### PR DESCRIPTION
This is because `-` is likely to appear in env and/or service names in the future. For those, we might expect e.g.: `[a-z_-]` - typical URL/path-safe chars

`;` is very unlikely to be allowed in that sort of context

`:` would violate the JWT spec (RFC 7519) - it specifies `iss` as a StringOrURI value, which says `any value containing a ":" character MUST be a URI`

`~` actually _is_ URL-safe in many contexts, and where we've used it in the past, it is an optional extra for tagging